### PR TITLE
Add speech playback for flashcards

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A simple browser game for kids to learn basic Chinese characters using a board-g
 4. Choose the correct zhuyin to earn ⭐ points. The phonetic symbols are shown vertically in standard bopomofo style.
 5. Squares you answer correctly are marked with a ✔.
 6. Completing a lap around the board awards an extra +10 ⭐.
-7. Click the 🎵 icon to hear each reading, or listen automatically when a card opens.
+7. Each card will read the character aloud automatically. Click the 🎵 icon or the character to replay the sound.
 
 ## Tech
 

--- a/index.html
+++ b/index.html
@@ -218,6 +218,20 @@
             margin: 20px 0;
         }
 
+        .char-wrapper {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 10px;
+        }
+
+        .speak-btn {
+            background: none;
+            border: none;
+            font-size: 2rem;
+            cursor: pointer;
+        }
+
         .question {
             font-size: 1.3rem;
             margin-bottom: 30px;
@@ -351,7 +365,10 @@
     <!-- 字卡模態框 -->
     <div class="modal" id="modal">
         <div class="card">
-            <div class="chinese-char" id="chineseChar"></div>
+            <div class="char-wrapper">
+                <div class="chinese-char" id="chineseChar"></div>
+                <button class="speak-btn" id="speakBtn" aria-label="播放發音">🎵</button>
+            </div>
             <div class="question">請選擇正確的注音</div>
             
             <div class="options" id="options">
@@ -435,6 +452,7 @@
             rollBtn: document.getElementById('rollBtn'),
             modal: document.getElementById('modal'),
             chineseChar: document.getElementById('chineseChar'),
+            speakBtn: document.getElementById('speakBtn'),
             options: document.getElementById('options'),
             result: document.getElementById('result'),
             continueBtn: document.getElementById('continueBtn'),
@@ -565,6 +583,8 @@
 
             elements.chineseChar.textContent = randomQuestion.char;
             elements.chineseChar.onclick = () => speak(randomQuestion.char);
+            elements.speakBtn.onclick = () => speak(randomQuestion.char);
+            speak(randomQuestion.char);
 
             // 清空並重新創建選項
             elements.options.innerHTML = '';


### PR DESCRIPTION
## Summary
- allow flashcards to speak characters on open
- provide speaker button next to each character
- document how to replay the audio

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68404ac9d3ec8320bb7f984187a609e7