### PR TITLE
Fix overlay masking character selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -370,6 +370,11 @@
             z-index: 1000;
         }
 
+        /* Ensure overlay stays hidden when the hidden class is applied */
+        .battle-overlay.hidden {
+            display: none;
+        }
+
         .battle-container {
             display: flex;
             align-items: center;


### PR DESCRIPTION
## Summary
- ensure `.battle-overlay` hides when `hidden` is applied so the VS boss screen doesn't appear before rolling

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68428f47d78883209c643c6d82ca6368