### PR TITLE
Use icons for start and end cells

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ A simple browser game for kids to learn basic Chinese characters using a board-g
 4. When you land on a square, a flashcard appears with a Chinese character and three zhuyin options.
 5. Choose the correct zhuyin to earn ⭐ points. The phonetic symbols are shown vertically in standard bopomofo style.
 6. Squares you answer correctly are marked with a ✔.
-7. Completing a lap around the board awards an extra +10 ⭐.
-8. A boss waits on the final square. Answer three questions in a row to defeat it! A wrong answer shows a losing icon and moves you back ten spaces.
-9. Click the 🎵 icon to hear each reading, or listen automatically when a card opens.
+7. The board's first and last cells are shown with 🚩 and 🏁 icons.
+8. Completing a lap around the board awards an extra +10 ⭐.
+9. A boss waits on the final square. Answer three questions in a row to defeat it! A wrong answer shows a losing icon and moves you back ten spaces.
+10. Click the 🎵 icon to hear each reading, or listen automatically when a card opens.
 
 ## Tech
 

--- a/index.html
+++ b/index.html
@@ -81,9 +81,13 @@
             box-shadow: 0 0 10px rgba(0,0,0,0.3);
         }
 
-        .cell:nth-child(1) {
+        .start-cell {
             background: linear-gradient(45deg, #ff6b6b, #feca57);
             color: white;
+        }
+
+        .end-cell {
+            background: linear-gradient(45deg, #a8e6cf, #88d8c0);
         }
 
         .cell:nth-child(20) {
@@ -567,9 +571,11 @@ function createBoard() {
             cell.dataset.col = c;
             cell.dataset.index = idx;
             if (r === 0 && c === 0) {
-                cell.textContent = '起點';
+                cell.textContent = '🚩';
+                cell.classList.add('start-cell');
             } else if (r === GRID_SIZE - 1 && c === GRID_SIZE - 1) {
-                cell.textContent = '終點';
+                cell.textContent = '🏁';
+                cell.classList.add('end-cell');
             } else {
                 cell.textContent = idx + 1;
             }


### PR DESCRIPTION
## Summary
- mark the first and last cells with 🚩 and 🏁
- style new `.start-cell` and `.end-cell` classes
- mention start/end icons in the README

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6842c49591d08320ad5f3a1b0a225820