### PR TITLE
Remove numbers from game board

### DIFF
--- a/index.html
+++ b/index.html
@@ -584,7 +584,7 @@ function createBoard() {
                 cell.textContent = '🏁';
                 cell.classList.add('end-cell');
             } else {
-                cell.textContent = idx + 1;
+                cell.textContent = '';
             }
             elements.board.appendChild(cell);
         }


### PR DESCRIPTION
## Summary
- hide numbers on standard cells so the board only shows icons

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6842c83037cc8320a6dfd41dc4c82da0