### PR TITLE
Add mobile-friendly board panning

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,8 +14,9 @@
         body {
             font-family: 'Arial', sans-serif;
             background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-            min-height: 100vh;
+            height: 100vh;
             padding: 20px;
+            overflow: hidden; /* 固定畫面避免出現 scroll bar */
         }
 
         .game-container {
@@ -24,7 +25,10 @@
             background: white;
             border-radius: 20px;
             box-shadow: 0 10px 30px rgba(0,0,0,0.2);
-            overflow: auto;
+            height: 100%;
+            overflow: hidden; /* 容器本身不顯示滾動條 */
+            display: flex;
+            flex-direction: column;
         }
 
         .header {
@@ -61,6 +65,13 @@
             padding: 20px;
             background: #e8f5e8;
             overflow: auto;
+            flex: 1;
+            -webkit-overflow-scrolling: touch;
+            scrollbar-width: none; /* Firefox 隱藏滾動條 */
+        }
+
+        .board::-webkit-scrollbar {
+            display: none; /* Chrome/Safari 隱藏滾動條 */
         }
 
         .goal-arrow {
@@ -142,6 +153,7 @@
             padding: 20px;
             text-align: center;
             background: #f8f9fa;
+            flex-shrink: 0; /* 使控制區塊不被壓縮 */
         }
 
         .dice {


### PR DESCRIPTION
## Summary
- prevent page scrolling on mobile
- allow game board to be swiped without showing scrollbars

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_6842ce07a8f48320b9c5bfe00fc08530