### PR TITLE
Enable swipe controls for player movement

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A simple browser game for kids to learn basic Chinese characters using a board-g
 8. Completing a lap around the board awards an extra +10 ⭐.
 9. A boss waits on the final square. Answer three questions in a row to defeat it! A wrong answer shows a losing icon and moves you back ten spaces.
 10. Click the 🎵 icon to hear each reading, or listen automatically when a card opens.
+11. On touch devices, swipe across the board to move your character.
 
 ## Tech
 

--- a/index.html
+++ b/index.html
@@ -592,6 +592,9 @@ function initGame() {
     showDirections();
     elements.board.addEventListener('scroll', checkGoalVisibility);
     window.addEventListener('resize', checkGoalVisibility);
+    elements.board.addEventListener('touchstart', onTouchStart, { passive: false });
+    elements.board.addEventListener('touchmove', onTouchMove, { passive: false });
+    elements.board.addEventListener('touchend', onTouchEnd, { passive: false });
     checkGoalVisibility();
 }
 
@@ -805,6 +808,37 @@ function showCharacterModal() {
         elements.charOptions.appendChild(el);
     });
     elements.charModal.classList.add('show');
+}
+
+let touchStartX = null;
+let touchStartY = null;
+
+function onTouchStart(e) {
+    if (e.touches.length !== 1) return;
+    touchStartX = e.touches[0].clientX;
+    touchStartY = e.touches[0].clientY;
+}
+
+function onTouchMove(e) {
+    if (touchStartX === null) return;
+    e.preventDefault();
+}
+
+function onTouchEnd(e) {
+    if (touchStartX === null) return;
+    const dx = e.changedTouches[0].clientX - touchStartX;
+    const dy = e.changedTouches[0].clientY - touchStartY;
+    const absX = Math.abs(dx);
+    const absY = Math.abs(dy);
+    const threshold = 30;
+    if (Math.max(absX, absY) > threshold) {
+        if (absX > absY) {
+            chooseDirection(dx > 0 ? 'right' : 'left');
+        } else {
+            chooseDirection(dy > 0 ? 'down' : 'up');
+        }
+    }
+    touchStartX = touchStartY = null;
 }
 
 document.addEventListener('DOMContentLoaded', initGame);


### PR DESCRIPTION
## Summary
- let the user swipe on the board to move the player token
- document swipe gesture in the README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6842cfce0dbc8320991e550f5a693bfa