### PR TITLE
Fix disappearing player

### DIFF
--- a/index.html
+++ b/index.html
@@ -638,11 +638,15 @@ function createBoard() {
 function positionPlayer() {
     const selector = `.cell[data-row="${gameState.row}"][data-col="${gameState.col}"]`;
     const cell = elements.board.querySelector(selector);
-    const cellRect = cell.getBoundingClientRect();
-    const boardRect = elements.board.getBoundingClientRect();
-    const x = cellRect.left - boardRect.left + cellRect.width / 2 - 15;
-    const y = cellRect.top - boardRect.top + cellRect.height / 2 - 15;
-    elements.player.style.transform = `translate(${x}px, ${y}px)`;
+    const x = cell.offsetLeft + cell.offsetWidth / 2 - 15;
+    const y = cell.offsetTop + cell.offsetHeight / 2 - 15;
+
+    const maxX = elements.board.scrollWidth - elements.player.offsetWidth;
+    const maxY = elements.board.scrollHeight - elements.player.offsetHeight;
+    const clampedX = Math.max(0, Math.min(x, maxX));
+    const clampedY = Math.max(0, Math.min(y, maxY));
+
+    elements.player.style.transform = `translate(${clampedX}px, ${clampedY}px)`;
     cell.scrollIntoView({behavior: 'smooth', block: 'center', inline: 'center'});
     checkGoalVisibility();
 }


### PR DESCRIPTION
## Summary
- fix positioning math so scrolling doesn't offset the token
- clamp player coordinates to board size to avoid leaving the screen

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6842d0de2e6c8320bbb7b0536a86f797