### PR TITLE
Fix CDN version for pinyin4js

### DIFF
--- a/index.html
+++ b/index.html
@@ -490,7 +490,8 @@
             100% { transform: scale(1); opacity: 1; }
         }
     </style>
-    <script src="https://cdn.jsdelivr.net/npm/pinyin4js@2.2.0/dist/pinyin4js.min.js"></script>
+    <!-- Load latest pinyin4js from CDN -->
+    <script src="https://cdn.jsdelivr.net/npm/pinyin4js/dist/pinyin4js.min.js"></script>
 </head>
 <body>
     <div class="game-container">


### PR DESCRIPTION
## Summary
- point the CDN script tag at the latest pinyin4js build so it resolves correctly

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6843b0a697f083208e12f2131da00f10